### PR TITLE
Implement trailing slash fix for data resource

### DIFF
--- a/R/SDMXREST21RequestBuilder-methods.R
+++ b/R/SDMXREST21RequestBuilder-methods.R
@@ -113,10 +113,10 @@ SDMXREST21RequestBuilder <- function(regUrl, repoUrl, accessKey = NULL,
       if(is.null(obj@key)) obj@key = "all"
       req <- sprintf("%s/data/%s/%s",obj@repoUrl, obj@flowRef, obj@key)
       if(skipProviderId){
-        req <- paste0(req, "/")
+        if(!skipTrailingSlash) req <- paste0(req, "/")
       }else{
         req <- paste(req, ifelse(forceProviderId, obj@providerId, "all"), sep = "/")
-        req <- paste0(req, "/")
+        if(!skipTrailingSlash) req <- paste0(req, "/")
       }
       
       #DataQuery


### PR DESCRIPTION
The trailing slash fix ([06d03de](https://github.com/opensdmx/rsdmx/commit/06d03de)) for [issue #222](https://github.com/eblondel/rsdmx/issues/222), which is necessary for the ECB API, was only implemented for the 'dataflow' and 'datastructure' resources. This PR adds a fix for the 'data' resource, while respecting the _skipProviderId_ and _forceProviderId_ arguments.